### PR TITLE
feat: ban console.log

### DIFF
--- a/src/configs/base.js
+++ b/src/configs/base.js
@@ -24,7 +24,8 @@ export const baseConfig = async ({ env, exclude, fileRoots }) => {
       },
       rules: {
         ...js.configs.recommended.rules,
-        'no-alert': 'error'
+        'no-alert': 'error',
+        'no-console': ['error', { allow: ['warn', 'error'] }]
       }
     },
     {

--- a/src/configs/react.js
+++ b/src/configs/react.js
@@ -26,8 +26,6 @@ export const reactConfig = async ({ fileRoots, react, typescript }) => {
       rules: {
         ...reactPlugin.configs.recommended.rules,
         ...jsxA11yPlugin.configs.recommended.rules,
-        'no-alert': 'error',
-        'no-console': ['error', { allow: ['warn', 'error'] }],
         'react/function-component-definition': [
           'error',
           {


### PR DESCRIPTION
Add a rule banning console.log in by default. Previously, this was only banned in the browser. On the server, use a the `LoggingModule` from `@douglasneuroinformatics/libnest`. 